### PR TITLE
BUGFIX: Ensure old body appears on edit form

### DIFF
--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -4,6 +4,7 @@
   <%= f.label :title %>
   <%= f.text_field :title %>
 
+  <%= hidden_field_tag :original_body, @question.body %>
   <div id="react_question_body">
     <%= f.label :body %>
     <%= f.text_area :body %>

--- a/react/src/QuestionBodyInput.js
+++ b/react/src/QuestionBodyInput.js
@@ -12,6 +12,11 @@ class QuestionBodyInput extends Component {
     this.handleChange = this.handleChange.bind(this);
   }
 
+  componentWillMount() {
+    let originalBody = $('#original_body').val();
+    this.setState({ body: originalBody });
+  }
+
   handleChange(event) {
     let updatedBody = event.target.value;
     this.setState({ body: updatedBody });

--- a/spec/factories/question.rb
+++ b/spec/factories/question.rb
@@ -1,8 +1,12 @@
 FactoryGirl.define do
   factory :question do
     sequence(:title) { |num| "Question #{num}" }
-    body 'This is some text for a question I want to add. It has **markdown**.'
+    body 'This is some text for a question I want to add.'
     long_id 'abcdefg'
     user
+
+    factory :markdown_question do
+      body 'This body has some **markdown**.'
+    end
   end
 end

--- a/spec/features/questions/edit_a_question_with_react_spec.rb
+++ b/spec/features/questions/edit_a_question_with_react_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+feature 'edit a question with react component', %{
+  As a user
+  I want to edit a question using a react component
+  So that I can preview my question in processed markdown
+}, js: true do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:question) { FactoryGirl.create(:question) }
+
+  before do
+    sign_in_as(user)
+  end
+
+  scenario 'user can make changes to previous body of question' do
+    visit edit_question_path(question)
+
+    expect(page).to have_content(question.body)
+  end
+end


### PR DESCRIPTION
This fixes a bug where the react component wouldn't show the original body of the question when a previously created question was being edited.
