### PR TITLE
Specify code or text answer

### DIFF
--- a/app/assets/stylesheets/_preview.scss
+++ b/app/assets/stylesheets/_preview.scss
@@ -1,0 +1,10 @@
+.markdown-body p {
+  margin-bottom: 2px;
+}
+
+.body-preview {
+  border: 1px solid $medium-gray;
+  min-height: 200px;
+  min-width: 100%;
+  padding: 10px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,3 +16,4 @@
 @import 'file_upload';
 @import 'avatar';
 @import 'logo';
+@import 'preview';

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -57,7 +57,7 @@ class QuestionsController < ApplicationController
   private
 
   def question_params
-    params.require(:question).permit(:title, :body)
+    params.require(:question).permit(:title, :body, :code_question)
   end
 
   def check_question_owner

--- a/app/facades/markdown_question.rb
+++ b/app/facades/markdown_question.rb
@@ -17,4 +17,12 @@ class MarkdownQuestion
   def body_raw
     @question.body
   end
+
+  def code_question
+    if @question.code_question
+      '<p><i class="fa fa-file-code-o"></i> Code-Based Answers</p>'
+    else
+      '<p><i class="fa fa-file-text-o"></i> Text-Based Answers</p>'
+    end
+  end
 end

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -4,6 +4,14 @@
   <%= f.label :title %>
   <%= f.text_field :title %>
 
+  <div id="question-type">
+    <%= f.radio_button :code_question, false %>
+    <%= f.label :code_question_true, 'Text-Based Answers' %>
+
+    <%= f.radio_button :code_question, true %>
+    <%= f.label :code_question_false, 'Code-Based Answers' %>
+  </div>
+
   <%= hidden_field_tag :original_body, @question.body %>
   <div id="react_question_body_input">
     <%= f.label :body %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,4 +1,7 @@
 <h2><%= @question.title %></h2>
+
+<%= render inline: @question.code_question %>
+
 <p class="shareable-link">
   Shareable Link:
   <%= link_to @shareable_link, @shareable_link %>

--- a/db/migrate/20160718141929_add_code_question_to_questions.rb
+++ b/db/migrate/20160718141929_add_code_question_to_questions.rb
@@ -1,0 +1,5 @@
+class AddCodeQuestionToQuestions < ActiveRecord::Migration
+  def change
+    add_column :questions, :code_question, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160714121831) do
+ActiveRecord::Schema.define(version: 20160718141929) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,12 +26,13 @@ ActiveRecord::Schema.define(version: 20160714121831) do
   end
 
   create_table "questions", force: :cascade do |t|
-    t.string   "title",      null: false
-    t.text     "body",       null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer  "user_id",    null: false
-    t.string   "long_id",    null: false
+    t.string   "title",                         null: false
+    t.text     "body",                          null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.integer  "user_id",                       null: false
+    t.string   "long_id",                       null: false
+    t.boolean  "code_question", default: false, null: false
   end
 
   add_index "questions", ["long_id"], name: "index_questions_on_long_id", using: :btree

--- a/react/src/QuestionBodyInput.js
+++ b/react/src/QuestionBodyInput.js
@@ -41,7 +41,9 @@ class QuestionBodyInput extends Component {
         </div>
         <div className='columns hide-for-small-only medium-6'>
           <p>Preview:</p>
-          <Markdown source={this.state.body} options={markdown_options} />
+          <div className="body-preview">
+            <Markdown source={this.state.body} options={markdown_options} />
+          </div>
         </div>
       </div>
     );

--- a/spec/facades/markdown_question_spec.rb
+++ b/spec/facades/markdown_question_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe MarkdownQuestion do
+  let(:question) { FactoryGirl.create(:question) }
+  let(:markdown_question) { MarkdownQuestion.new(question.id) }
+
+  describe '.new' do
+    it 'finds a question based on the id' do
+      expect(markdown_question.question).to eq(question)
+    end
+  end
+
+  describe '#body' do
+    it 'returns an html formatted version of the question body' do
+      expect(markdown_question.body).to include('<p>This is some text for a '\
+                                                'question I want to add.</p>')
+    end
+  end
+
+  describe '#body_raw' do
+    it 'returns the original text of the body, not formatted in html' do
+      expect(markdown_question.body_raw).to eq('This is some text for a '\
+                                               'question I want to add.')
+      expect(markdown_question.body_raw).not_to include('<p>')
+    end
+  end
+
+  describe "#code_question" do
+    it 'returns the html to display the code question label if code question' do
+      markdown_question.question.code_question = true
+
+      expect(markdown_question.code_question).to eq('<p><i class="fa fa-file-c'\
+                                                    'ode-o"></i> Code-Based An'\
+                                                    'swers</p>')
+    end
+
+    it 'returns the html to dispaly the text question lable if text question' do
+      expect(markdown_question.code_question).to eq('<p><i class="fa fa-file-t'\
+                                                    'ext-o"></i> Text-Based An'\
+                                                    'swers</p>')
+    end
+  end
+end

--- a/spec/factories/question.rb
+++ b/spec/factories/question.rb
@@ -4,9 +4,14 @@ FactoryGirl.define do
     body 'This is some text for a question I want to add.'
     long_id 'abcdefg'
     user
+    code_question false
 
     factory :markdown_question do
       body 'This body has some **markdown**.'
+    end
+
+    factory :code_question do
+      code_question true
     end
   end
 end

--- a/spec/features/questions/specify_code_or_text_answer_spec.rb
+++ b/spec/features/questions/specify_code_or_text_answer_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+feature 'create a code question', %{
+  As a user
+  I want to specify if I question should be a code question
+  So that students can enter code for their answer
+} do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:question) { FactoryGirl.attributes_for(:question) }
+  before do
+    sign_in_as(user)
+    new_question_path
+  end
+
+  scenario 'user selects text-based question' do
+    choose('Text-Based Answer')
+
+    click_button('Save Question')
+
+    expect(page).to have_content(question[:title])
+    expect(page).to have_content('Text-Based Answers')
+  end
+
+  scenario 'user selects code-based question' do
+    choose('Code-Based Answer')
+
+    click_button('Save Question')
+
+    expect(page).to have_content(question[:title])
+    expect(page).to have_content('Code-Based Answers')
+  end
+
+  scenario 'preference for code remains when viewing edit form' do
+    question = FactoryGirl.create(:code_question)
+
+    visit edit_question_path(question)
+
+    expect(input('#code_based_question')).to be_checked
+  end
+
+  scenario 'preference for text remains when viewing edit form' do
+    question = FactoryGirl.create(:question)
+
+    visit edit_question_path(question)
+
+    expect(input('#text_based_question')).to be_checked
+  end
+end
+
+def fill_in_question_form
+  fill_in('Title', with: question[:title])
+  fill_in('Body', with: question[:body])
+end

--- a/spec/features/questions/specify_code_or_text_answer_spec.rb
+++ b/spec/features/questions/specify_code_or_text_answer_spec.rb
@@ -7,14 +7,16 @@ feature 'create a code question', %{
 } do
   let(:user) { FactoryGirl.create(:user) }
   let(:question) { FactoryGirl.attributes_for(:question) }
+
   before do
     sign_in_as(user)
-    new_question_path
+    visit new_question_path
   end
 
   scenario 'user selects text-based question' do
-    choose('Text-Based Answer')
+    choose('question_code_question_false')
 
+    fill_in_question_form_with(question)
     click_button('Save Question')
 
     expect(page).to have_content(question[:title])
@@ -22,8 +24,9 @@ feature 'create a code question', %{
   end
 
   scenario 'user selects code-based question' do
-    choose('Code-Based Answer')
+    choose('question_code_question_true')
 
+    fill_in_question_form_with(question)
     click_button('Save Question')
 
     expect(page).to have_content(question[:title])
@@ -31,23 +34,23 @@ feature 'create a code question', %{
   end
 
   scenario 'preference for code remains when viewing edit form' do
-    question = FactoryGirl.create(:code_question)
+    question = FactoryGirl.create(:code_question, user: user)
 
     visit edit_question_path(question)
 
-    expect(input('#code_based_question_true')).to be_checked
+    expect(find('#question_code_question_true')).to be_checked
   end
 
   scenario 'preference for text remains when viewing edit form' do
-    question = FactoryGirl.create(:question)
+    question = FactoryGirl.create(:question, user: user)
 
     visit edit_question_path(question)
 
-    expect(input('#text_based_question_false')).to be_checked
+    expect(find('#question_code_question_false')).to be_checked
   end
 end
 
-def fill_in_question_form
+def fill_in_question_form_with(question)
   fill_in('Title', with: question[:title])
   fill_in('Body', with: question[:body])
 end

--- a/spec/features/questions/specify_code_or_text_answer_spec.rb
+++ b/spec/features/questions/specify_code_or_text_answer_spec.rb
@@ -35,7 +35,7 @@ feature 'create a code question', %{
 
     visit edit_question_path(question)
 
-    expect(input('#code_based_question')).to be_checked
+    expect(input('#code_based_question_true')).to be_checked
   end
 
   scenario 'preference for text remains when viewing edit form' do
@@ -43,7 +43,7 @@ feature 'create a code question', %{
 
     visit edit_question_path(question)
 
-    expect(input('#text_based_question')).to be_checked
+    expect(input('#text_based_question_false')).to be_checked
   end
 end
 


### PR DESCRIPTION
Allows user to specify if answers should be text or code-based.
